### PR TITLE
added captureBeyondViewport to page.screenshot to avoid flickering

### DIFF
--- a/index.js
+++ b/index.js
@@ -383,6 +383,7 @@ async function renderUrlToImageAsync(browser, pageConfig, url, path) {
     await page.screenshot({
       path,
       type: "png",
+      captureBeyondViewport: false,
       clip: {
         x: 0,
         y: 0,


### PR DESCRIPTION
See also https://github.com/puppeteer/puppeteer/issues/7043. Happens for example sporadically with atomic revive calendar card, card rerenders when viewport is changed and that happens without this parameter being set.