### PR TITLE
Removed initiating new mqtt on error

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,17 +173,7 @@ async function mqttConnect() {
   });
   mqttClient.on("error",function(error){
     console.error("MQTT error:" + error);
-    new Promise(r => setTimeout(r, 60000)); //wait 1 minute
-    //process.exit(1);
-    mqttConnect();
   });
-  // not sure if this is needed
-  // mqttClient.on("disconnect",function(d){
-  //   console.error("MQTT disconnect:" + d);
-  //   new Promise(r => setTimeout(r, 60000)); //wait 1 minute
-  //   //process.exit(1);
-  //   mqttConnect();
-  // });
 }
 
 async function mqttSendState(state) {


### PR DESCRIPTION
When the MQTT server becomes unavailable, the current way would create a lot of new MQTT instances, until resource exhaustion. 
The MQTT.js library already has an automatic reconnect every second enabled, which could be changed by using the `reconnectPeriod` option to a different value in milliseconds.