### PR TITLE
Add  multiarch builds (ARM64, ARMv7)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v3
-      -
         name: QEMU Setup
         uses: docker/setup-qemu-action@v3.0.0
+      -
+        name: Checkout
+        uses: actions/checkout@v3
       -
         name: Docker meta
         id: meta

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,9 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       -
+        name: QEMU Setup
+        uses: docker/setup-qemu-action@v3.0.0
+      -
         name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -44,3 +47,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-alpine
+FROM node:18-alpine3.18
 
 WORKDIR /app
 


### PR DESCRIPTION
This PR adds QEMU to the docker workflow so that the docker action can build for architectures other than AMD64; this lets us add ARM64 and ARMv7 builds so this can run (natively) on M1 macs and modern Raspberry PIs

I had to bump the alpine version since 3.15 didn't have chromium in their ARMv7 repos; which also required me to bump node to 18. It all builds without error and after testing the image out now everything seems to work just fine on a Raspberry Pi 4.
